### PR TITLE
Removing remaining argo references

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ yarn generate --type=CHECKOUT_POST_PURCHASE --template=vanilla-typescript
 ### Available extensions
 
 - CHECKOUT_POST_PURCHASE
-- CHECKOUT_ARGO_EXTENSION
+- CHECKOUT_UI_EXTENSION

--- a/scripts/generate/generate-src.ts
+++ b/scripts/generate/generate-src.ts
@@ -24,7 +24,6 @@ const TEMPLATES = new Map([
 
 export const EXTENSION_TEMPLATE_MAP = new Map([
   ['CHECKOUT_POST_PURCHASE', 'post-purchase'],
-  ['CHECKOUT_ARGO_EXTENSION', 'checkout'],
   ['CHECKOUT_UI_EXTENSION', 'checkout'],
 ]);
 

--- a/scripts/generate/generate-src.ts
+++ b/scripts/generate/generate-src.ts
@@ -24,6 +24,7 @@ const TEMPLATES = new Map([
 
 export const EXTENSION_TEMPLATE_MAP = new Map([
   ['CHECKOUT_POST_PURCHASE', 'post-purchase'],
+  ['CHECKOUT_ARGO_EXTENSION', 'checkout'],
   ['CHECKOUT_UI_EXTENSION', 'checkout'],
 ]);
 

--- a/scripts/generate/templates/post-purchase/src/index.ts
+++ b/scripts/generate/templates/post-purchase/src/index.ts
@@ -55,7 +55,7 @@ async function getRenderData(): Promise<InitialState> {
 /**
  * Entry point for the `Render` Extension Point
  *
- * Returns markup composed of Argo components.  The Render extension can
+ * Returns markup composed of remote UI components.  The Render extension can
  * optionally make use of data stored during `ShouldRender` extension point to
  * expedite time-to-first-meaningful-paint.
  */

--- a/scripts/generate/templates/post-purchase/src/index.tsx
+++ b/scripts/generate/templates/post-purchase/src/index.tsx
@@ -59,7 +59,7 @@ async function getRenderData(): Promise<InitialState> {
 /**
  * Entry point for the `Render` Extension Point
  *
- * Returns markup composed of Argo components.  The Render extension can
+ * Returns markup composed of remote UI components.  The Render extension can
  * optionally make use of data stored during `ShouldRender` extension point to
  * expedite time-to-first-meaningful-paint.
  */


### PR DESCRIPTION
Removing all remaining references to the name Argo.

Reviewers, can you please confirm that it's okay to remove the `CHECKOUT_ARGO_EXTENSION` type from the source generation script?