### PR TITLE
fix: package name in clean up script for post purchase

### DIFF
--- a/scripts/generate/clean-up.ts
+++ b/scripts/generate/clean-up.ts
@@ -21,7 +21,7 @@ export function cleanUp(type: string) {
     delete json.dependencies['@shopify/checkout-ui-extensions-react'];
   } else {
     delete json.dependencies['@shopify/post-purchase-ui-extensions'];
-    delete json.dependencies['@shopify/post-purchase-ui-extensions--react'];
+    delete json.dependencies['@shopify/post-purchase-ui-extensions-react'];
   }
 
   const newPackage = JSON.stringify(json, null, 2);


### PR DESCRIPTION
The clean up script contains the wrong package name. This causes an issue when running `shopify extension serve` as it fails with this error: 
```
✗ Extension template references invalid renderer package please contact Shopify for help.
```