### PR TITLE
Remove template generation for CHECKOUT_ARGO_EXTENSION

### DIFF
--- a/scripts/generate/generate-src.ts
+++ b/scripts/generate/generate-src.ts
@@ -24,7 +24,6 @@ const TEMPLATES = new Map([
 
 export const EXTENSION_TEMPLATE_MAP = new Map([
   ['CHECKOUT_POST_PURCHASE', 'post-purchase'],
-  ['CHECKOUT_ARGO_EXTENSION', 'checkout'],
   ['CHECKOUT_UI_EXTENSION', 'checkout'],
 ]);
 


### PR DESCRIPTION
Now that no one is generating extensions of type `CHECKOUT_ARGO_EXTENSION`, we can remove the reference to generate templates for this type.