### PR TITLE
Add name to extension config for checkout-ui-extensions

### DIFF
--- a/scripts/generate/templates/checkout/files/extension.config.yml
+++ b/scripts/generate/templates/checkout/files/extension.config.yml
@@ -1,4 +1,5 @@
 ---
+name: App Feature
 extension_points:
   - Checkout::Feature::Render
 # metafields:


### PR DESCRIPTION
Fixes https://github.com/Shopify/checkout-web/issues/6020

We want to allow partners to provide us with a merchant facing name for their extension that will be surfaced in the editor and used by the merchant to identify the extension. Right now, we are using a default one for the sake of time, but we are thinking an iteration of that would be to prompt partners on the CLI to specify one so it does not confuse merchants and enforcing the name as the same time. 

Pending questions:
- Should we use another default? 
- Should we already nest the configuration instead of having it at the top-level?
- Is the configuration key name correctly?